### PR TITLE
Fix: Ensure correct button is displayed for web and print views.

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,9 +202,7 @@
         .dark #theme-toggle .fa-moon { display: none; }
 
 
-        @media screen {
-            .only-print { display: none; }
-        }
+        .only-print { display: none !important; }
         
         /* --- UPDATED PRINT STYLES --- */
         @media print {


### PR DESCRIPTION
The user reported that two buttons were showing on the web view instead of one. The 'View Interactive' button, intended only for print, was appearing alongside the 'Tailor' button.

This was caused by a CSS specificity issue where Tailwind's utility classes overrode the custom style meant to hide the print-only button on screen.

This fix resolves the issue by adding `!important` to the `.only-print { display: none; }` rule, ensuring it is correctly hidden in the web view.

The corresponding rule to hide the web-only button (`.no-print`) during printing was already present and correct in the codebase.